### PR TITLE
Update model zoo to allow simpler import for inference

### DIFF
--- a/gluonfr/__init__.py
+++ b/gluonfr/__init__.py
@@ -41,7 +41,7 @@ except ImportError:
 __version__ = '0.1.0'
 
 from . import data
-# from . import model_zoo
+from . import model_zoo
 from . import nn
 from . import utils
 from . import loss

--- a/gluonfr/model_zoo/attention_net.py
+++ b/gluonfr/model_zoo/attention_net.py
@@ -254,7 +254,7 @@ class AttentionNetFace(FrBase):
 
     """
 
-    def __init__(self, modules, p, t, r, classes=-1,
+    def __init__(self, classes, modules, p, t, r,
                  weight_norm=False, feature_norm=False, embedding_size=512,
                  need_cls_layer=True, **kwargs):
         super().__init__(classes, embedding_size, weight_norm, feature_norm, need_cls_layer, **kwargs)
@@ -331,18 +331,18 @@ def get_attention_net(classes, num_layers, **kwargs):
     return net
 
 
-def get_attention_face(classes, num_layers, embedding_size, need_cls_layer=True, **kwargs):
+def get_attention_face(classes=-1, num_layers=128, embedding_size=512, need_cls_layer=True, **kwargs):
     r"""AttentionNet Model for 112x112 face images from
     `"Residual Attention Network for Image Classification"
     <https://arxiv.org/abs/1704.06904>`_ paper.
 
     Parameters
     ----------
-    classes : int,
+    classes : int, -1
         Number of classification classes.
-    num_layers : int
+    num_layers : int, 128
         Numbers of layers. Options are 56, 92, 128, 164, 236, 452.
-    embedding_size: int
+    embedding_size: int, 256
         Feature dimensions of the embedding layers.
     need_cls_layer : bool, default True
         Whether to use NormDense output layer.
@@ -353,7 +353,7 @@ def get_attention_face(classes, num_layers, embedding_size, need_cls_layer=True,
     ptr, modules = attention_net_spec[num_layers]
     assert len(ptr) == len(modules) == 3
     p, t, r = ptr
-    net = AttentionNetFace(modules, p, t, r, classes, embedding_size=embedding_size, need_cls_layer=need_cls_layer, **kwargs)
+    net = AttentionNetFace(classes, modules, p, t, r, embedding_size=embedding_size, need_cls_layer=need_cls_layer, **kwargs)
     return net
 
 

--- a/gluonfr/model_zoo/attention_net.py
+++ b/gluonfr/model_zoo/attention_net.py
@@ -254,7 +254,7 @@ class AttentionNetFace(FrBase):
 
     """
 
-    def __init__(self, classes, modules, p, t, r,
+    def __init__(self, modules, p, t, r, classes=-1,
                  weight_norm=False, feature_norm=False, embedding_size=512,
                  need_cls_layer=True, **kwargs):
         super().__init__(classes, embedding_size, weight_norm, feature_norm, need_cls_layer, **kwargs)
@@ -331,7 +331,7 @@ def get_attention_net(classes, num_layers, **kwargs):
     return net
 
 
-def get_attention_face(classes, num_layers, embedding_size, **kwargs):
+def get_attention_face(classes, num_layers, embedding_size, need_cls_layer=True, **kwargs):
     r"""AttentionNet Model for 112x112 face images from
     `"Residual Attention Network for Image Classification"
     <https://arxiv.org/abs/1704.06904>`_ paper.
@@ -344,6 +344,8 @@ def get_attention_face(classes, num_layers, embedding_size, **kwargs):
         Numbers of layers. Options are 56, 92, 128, 164, 236, 452.
     embedding_size: int
         Feature dimensions of the embedding layers.
+    need_cls_layer : bool, default True
+        Whether to use NormDense output layer.
     """
     assert num_layers in attention_net_spec, \
         "Invalid number of layers: %d. Options are %s" % (
@@ -351,83 +353,101 @@ def get_attention_face(classes, num_layers, embedding_size, **kwargs):
     ptr, modules = attention_net_spec[num_layers]
     assert len(ptr) == len(modules) == 3
     p, t, r = ptr
-    net = AttentionNetFace(classes, modules, p, t, r, embedding_size=embedding_size, **kwargs)
+    net = AttentionNetFace(modules, p, t, r, classes, embedding_size=embedding_size, need_cls_layer=need_cls_layer, **kwargs)
     return net
 
 
-def attention_net56(classes, **kwargs):
+def attention_net56(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 56 Model from
-       `"Residual Attention Network for Image Classification"
-       <https://arxiv.org/abs/1704.06904>`_ paper.
-
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 56, **kwargs)
+    `"Residual Attention Network for Image Classification"
+    <https://arxiv.org/abs/1704.06904>`_ paper.
 
 
-def attention_net92(classes, **kwargs):
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return get_attention_net(classes, 56, need_cls_layer=need_cls_layer, **kwargs)
+
+
+def attention_net92(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 92 Model from
        `"Residual Attention Network for Image Classification"
        <https://arxiv.org/abs/1704.06904>`_ paper.
 
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 92, **kwargs)
+
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+
+    """
+    return get_attention_net(classes, 92, need_cls_layer=need_cls_layer, **kwargs)
 
 
-def attention_net128(classes, **kwargs):
+def attention_net128(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 128 Model from
        `"Residual Attention Network for Image Classification"
        <https://arxiv.org/abs/1704.06904>`_ paper.
 
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 128, **kwargs)
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return get_attention_net(classes, 128, need_cls_layer=need_cls_layer, **kwargs)
 
 
-def attention_net164(classes, **kwargs):
+def attention_net164(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 164 Model from
        `"Residual Attention Network for Image Classification"
        <https://arxiv.org/abs/1704.06904>`_ paper.
 
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 164, **kwargs)
+
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return get_attention_net(classes, 164, need_cls_layer=need_cls_layer, **kwargs)
 
 
-def attention_net236(classes, **kwargs):
+def attention_net236(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 236 Model from
        `"Residual Attention Network for Image Classification"
        <https://arxiv.org/abs/1704.06904>`_ paper.
 
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 236, **kwargs)
+
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return get_attention_net(classes, 236, need_cls_layer=need_cls_layer, **kwargs)
 
 
-def attention_net452(classes, **kwargs):
+def attention_net452(classes=-1, need_cls_layer=True, **kwargs):
     r"""AttentionNet 452 Model from
        `"Residual Attention Network for Image Classification"
        <https://arxiv.org/abs/1704.06904>`_ paper.
 
-       Parameters
-       ----------
-       classes : int,
-           Number of classification classes.
-       """
-    return get_attention_net(classes, 452, **kwargs)
+
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return get_attention_net(classes, 452, need_cls_layer=need_cls_layer, **kwargs)

--- a/gluonfr/model_zoo/mobile_facenet.py
+++ b/gluonfr/model_zoo/mobile_facenet.py
@@ -70,7 +70,7 @@ class Bottleneck(nn.HybridBlock):
 
 
 class MobileFaceNet(FrBase):
-    def __init__(self, classes, use_se=False, weight_norm=False,
+    def __init__(self, classes=-1, use_se=False, weight_norm=False,
                  feature_norm=False, need_cls_layer=True, **kwargs):
         super(MobileFaceNet, self).__init__(classes, 128, weight_norm,
                                             feature_norm, need_cls_layer, **kwargs)
@@ -95,7 +95,7 @@ class MobileFaceNet(FrBase):
 
 
 class MobileFaceNet_re(FrBase):
-    def __init__(self, classes, use_se=False, weight_norm=False,
+    def __init__(self, classes=-1, use_se=False, weight_norm=False,
                  feature_norm=False, need_cls_layer=True, **kwargs):
         super(MobileFaceNet_re, self).__init__(classes, 160, weight_norm,
                                                feature_norm, need_cls_layer, **kwargs)
@@ -120,9 +120,25 @@ class MobileFaceNet_re(FrBase):
                                   nn.Flatten())
 
 
-def get_mobile_facenet(classes, **kwargs):
-    return MobileFaceNet(classes, **kwargs)
+def get_mobile_facenet(classes=-1, need_cls_layer=True, **kwargs):
+    r"""
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return MobileFaceNet(classes=classes, need_cls_layer=need_cls_layer, **kwargs)
 
 
-def get_mobile_facenet_re(classes, **kwargs):
-    return get_mobile_facenet_re(classes, **kwargs)
+def get_mobile_facenet_re(classes=-1, need_cls_layer=True, **kwargs):
+    r"""
+    Parameters
+    ----------
+    classes : int, -1
+       Number of classification classes.
+    need_cls_layer : bool, default True
+       Whether to use NormDense output layer.
+    """
+    return MobileFaceNet_re(classes=classes, need_cls_layer=need_cls_layer, **kwargs)

--- a/gluonfr/model_zoo/se_resnet.py
+++ b/gluonfr/model_zoo/se_resnet.py
@@ -92,7 +92,7 @@ class SE_ResNetV2(FrBase):
         Enable thumbnail.
     """
 
-    def __init__(self, block, layers, channels, classes=1000, thumbnail=False,
+    def __init__(self, block, layers, channels, classes=-1, thumbnail=False,
                  embedding_size=512, weight_norm=False, feature_norm=False,
                  need_cls_layer=True, **kwargs):
         super(SE_ResNetV2, self).__init__(classes, embedding_size, weight_norm,

--- a/gluonfr/nn/basic_blocks.py
+++ b/gluonfr/nn/basic_blocks.py
@@ -101,7 +101,7 @@ class FrBase(nn.HybridBlock):
         When you only need embedding output, like you are predicting or training with triplet loss,
         you need to set it to False.
     """
-    def __init__(self, classes, embedding_size=512, weight_norm=False, feature_norm=False,
+    def __init__(self, classes=-1, embedding_size=512, weight_norm=False, feature_norm=False,
                  need_cls_layer=True, **kwargs):
         super(FrBase, self).__init__(**kwargs)
         self.need_cls_layer = need_cls_layer
@@ -109,6 +109,7 @@ class FrBase(nn.HybridBlock):
         self.features = None
 
         if need_cls_layer:
+            assert classes > 0, "When need_cls_layer=True, you need to specify a positive number of classes"
             self.output = NormDense(classes, weight_norm, feature_norm,
                                     in_units=embedding_size, prefix='output_')
 


### PR DESCRIPTION
Currently it is a bit awkward to use the model_zoo for inference because one need to specify classes even for inference.

Now one can simply do the following:

```python
import gluonfr as gfr

net = gfr.model_zoo.get_mobile_facenet(need_cls_layer=False)
```

and if users try to get a model without specifying class numbers like this:
```python
import gluonfr as gfr

net = gfr.model_zoo.get_mobile_facenet()
```
they get a warning:
```
AssertionError: When need_cls_layer=True, you need to specify a positive number of classes
```

Also re-activated the model zoo API in this PR and fixed bug for `get_mobile_facenet_re` function.

The changes should be backward compatible.